### PR TITLE
Remove dependency to obsolete concurrent library

### DIFF
--- a/colt/LEGAL/concurrent.LICENSE.txt
+++ b/colt/LEGAL/concurrent.LICENSE.txt
@@ -1,3 +1,0 @@
-All classes are released to the public domain and may be used for any purpose whatsoever without permission or acknowledgment. 
-Portions of the CopyOnWriteArrayList and ConcurrentReaderHashMap classes are adapted from Sun JDK source code. 
-These are copyright of Sun Microsystems, Inc, and are used with their kind permission.

--- a/colt/pom.xml
+++ b/colt/pom.xml
@@ -123,10 +123,5 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
       <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>concurrent</groupId>
-      <artifactId>concurrent</artifactId>
-      <version>1.3.4</version>
-    </dependency>
   </dependencies>
 </project>

--- a/colt/src/main/java/cern/colt/matrix/linalg/Smp.java
+++ b/colt/src/main/java/cern/colt/matrix/linalg/Smp.java
@@ -9,12 +9,12 @@ It is provided "as is" without expressed or implied warranty.
 package cern.colt.matrix.linalg;
 
 import cern.colt.matrix.DoubleMatrix2D;
-import EDU.oswego.cs.dl.util.concurrent.FJTask;
-import EDU.oswego.cs.dl.util.concurrent.FJTaskRunnerGroup;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
 /*
 */
 class Smp {
-	protected FJTaskRunnerGroup taskGroup; // a very efficient and light weight thread pool
+	protected ForkJoinPool taskGroup; // a very efficient and light weight thread pool
 
 	protected int maxThreads;	
 /**
@@ -24,24 +24,19 @@ protected Smp(int maxThreads) {
 	maxThreads = Math.max(1,maxThreads);
 	this.maxThreads = maxThreads;
 	if (maxThreads>1) {
-		this.taskGroup = new FJTaskRunnerGroup(maxThreads);
+		this.taskGroup = new ForkJoinPool(maxThreads);
 	}
 	else { // avoid parallel overhead
 		this.taskGroup = null;
 	}
 }
-/**
- * Clean up deamon threads, if necessary.
- */
-public void finalize() {
-	if (this.taskGroup!=null) this.taskGroup.interruptAll();
-}
 protected void run(final DoubleMatrix2D[] blocksA, final DoubleMatrix2D[] blocksB, final double[] results, final Matrix2DMatrix2DFunction function) {
-	final FJTask[] subTasks = new FJTask[blocksA.length];
+	final RecursiveAction[] subTasks = new RecursiveAction[blocksA.length];
 	for (int i=0; i<blocksA.length; i++) {
 		final int k = i;
-		subTasks[i] = new FJTask() { 
-			public void run() {
+		subTasks[i] = new RecursiveAction() {
+			@Override
+			protected void compute() {
 				double result = function.apply(blocksA[k],blocksB != null ? blocksB[k] : null);
 				if (results!=null) results[k] = result; 
 				//System.out.print("."); 
@@ -50,15 +45,14 @@ protected void run(final DoubleMatrix2D[] blocksA, final DoubleMatrix2D[] blocks
 	}
 
 	// run tasks and wait for completion
-	try { 
-		this.taskGroup.invoke(
-			new FJTask() {
-				public void run() {	
-					coInvoke(subTasks);	
-				}
+	this.taskGroup.invoke(
+		new RecursiveAction() {
+			@Override
+			protected void compute() {	
+				invokeAll(subTasks);	
 			}
-		);
-	} catch (InterruptedException exc) {}
+		}
+	);
 }
 protected DoubleMatrix2D[] splitBlockedNN(DoubleMatrix2D A, int threshold, long flops) {
 	/*
@@ -185,11 +179,5 @@ protected DoubleMatrix2D[] splitStridedNN(DoubleMatrix2D A, int threshold, long 
 		}
 	}
 	return blocks;
-}
-/**
- * Prints various snapshot statistics to System.out; Simply delegates to {@link EDU.oswego.cs.dl.util.concurrent.FJTaskRunnerGroup#stats}.
- */
-public void stats() {
-	if (this.taskGroup!=null) this.taskGroup.stats();
 }
 }

--- a/colt/src/main/java/cern/colt/matrix/linalg/SmpBlas.java
+++ b/colt/src/main/java/cern/colt/matrix/linalg/SmpBlas.java
@@ -10,7 +10,7 @@ package cern.colt.matrix.linalg;
 
 import cern.colt.matrix.DoubleMatrix1D;
 import cern.colt.matrix.DoubleMatrix2D;
-import EDU.oswego.cs.dl.util.concurrent.FJTask;
+import java.util.concurrent.RecursiveAction;
 /**
 Parallel implementation of the Basic Linear Algebra System for symmetric multi processing boxes.
 Currently only a few algorithms are parallelised; the others are fully functional, but run in sequential mode.
@@ -48,11 +48,8 @@ So if you're lucky, you get parallel performance for free.
 number of CPUs on a JVM, so there is no good way to automate defaults.</li>
 <li>Only improves performance on boxes with > 1 CPUs and VMs with <b>native threads</b>.</li>
 <li>Currently only improves performance when working on dense matrix types. On sparse types, performance is likely to degrade (because of the implementation of sub-range views)!</li>
-<li>Implemented using Doug Lea's fast lightweight task framework ({@link EDU.oswego.cs.dl.util.concurrent}) built upon Java threads, and geared for parallel computation.</li>
 </ul>
 
-@see EDU.oswego.cs.dl.util.concurrent.FJTaskRunnerGroup
-@see EDU.oswego.cs.dl.util.concurrent.FJTask
 @author wolfgang.hoschek@cern.ch
 @version 0.9, 16/04/2000
 */
@@ -198,7 +195,7 @@ public void dgemm(final boolean transposeA, final boolean transposeB, final doub
 	
 	// set up concurrent tasks
 	int span = width/noOfTasks;
-	final FJTask[] subTasks = new FJTask[noOfTasks];
+	final RecursiveAction[] subTasks = new RecursiveAction[noOfTasks];
 	for (int i=0; i<noOfTasks; i++) {
 		final int offset = i*span;
 		if (i==noOfTasks-1) span = width - span*i; // last span may be a bit larger
@@ -217,8 +214,9 @@ public void dgemm(final boolean transposeA, final boolean transposeB, final doub
 			CC = C.viewPart(offset,0,span,p);
 		}
 				
-		subTasks[i] = new FJTask() { 
-			public void run() { 
+		subTasks[i] = new RecursiveAction() {
+			@Override
+			protected void compute() { 
 				seqBlas.dgemm(transposeA,transposeB,alpha,AA,BB,beta,CC); 
 				//System.out.println("Hello "+offset); 
 			}
@@ -226,15 +224,14 @@ public void dgemm(final boolean transposeA, final boolean transposeB, final doub
 	}
 	
 	// run tasks and wait for completion
-	try { 
-		this.smp.taskGroup.invoke(
-			new FJTask() {
-				public void run() {	
-					coInvoke(subTasks);	
-				}
+	this.smp.taskGroup.invoke(
+		new RecursiveAction() {
+			@Override
+			protected void compute() {	
+				invokeAll(subTasks);	
 			}
-		);
-	} catch (InterruptedException exc) {}
+		}
+	);
 }
 public void dgemv(final boolean transposeA, final double alpha, DoubleMatrix2D A, final DoubleMatrix1D x, final double beta, DoubleMatrix1D y) {
 	/*
@@ -271,7 +268,7 @@ public void dgemv(final boolean transposeA, final double alpha, DoubleMatrix2D A
 	
 	// set up concurrent tasks
 	int span = width/noOfTasks;
-	final FJTask[] subTasks = new FJTask[noOfTasks];
+	final RecursiveAction[] subTasks = new RecursiveAction[noOfTasks];
 	for (int i=0; i<noOfTasks; i++) {
 		final int offset = i*span;
 		if (i==noOfTasks-1) span = width - span*i; // last span may be a bit larger
@@ -280,8 +277,9 @@ public void dgemv(final boolean transposeA, final double alpha, DoubleMatrix2D A
 		final DoubleMatrix2D AA = A.viewPart(offset,0,span,n);
 		final DoubleMatrix1D yy = y.viewPart(offset,span);
 				
-		subTasks[i] = new FJTask() { 
-			public void run() { 
+		subTasks[i] = new RecursiveAction() {
+			@Override
+			protected void compute() { 
 				seqBlas.dgemv(transposeA,alpha,AA,x,beta,yy); 
 				//System.out.println("Hello "+offset); 
 			}
@@ -289,15 +287,14 @@ public void dgemv(final boolean transposeA, final double alpha, DoubleMatrix2D A
 	}
 	
 	// run tasks and wait for completion
-	try { 
-		this.smp.taskGroup.invoke(
-			new FJTask() {
-				public void run() {	
-					coInvoke(subTasks);	
-				}
+	this.smp.taskGroup.invoke(
+		new RecursiveAction() {
+			@Override
+			protected void compute() {	
+				invokeAll(subTasks);	
 			}
-		);
-	} catch (InterruptedException exc) {}
+		}
+	);
 }
 public void dger(double alpha, DoubleMatrix1D x, DoubleMatrix1D y, DoubleMatrix2D A) {
 	seqBlas.dger(alpha,x,y,A);
@@ -365,12 +362,6 @@ protected double[] run(DoubleMatrix2D A, boolean collectResults, Matrix2DMatrix2
 		this.smp.run(blocks,null,results,fun);
 	}
 	return results;
-}
-/**
- * Prints various snapshot statistics to System.out; Simply delegates to {@link EDU.oswego.cs.dl.util.concurrent.FJTaskRunnerGroup#stats}.
- */
-public void stats() {
-	if (this.smp!=null) this.smp.stats();
 }
 private double xsum(DoubleMatrix2D A) {
 	double[] sums = run(A,true,


### PR DESCRIPTION
The COLT implementation from 2004 depends on pre-jdk5 concurrency
library by Doug Lea which is obsolete now and its successor is part of
JRE.
Replace the EDU.oswego.cs.dl.util.concurrent code with
java.util.concurrent and remove the dependency to concurrent library