### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Find an issue?   Need help?  See [JIRA](https://jira.blazegraph.com) or purchase
 
 Reporting a security issue: [Security Reporting](Security.md).
 
-###Quick Start with the Executable Jar
+### Quick Start with the Executable Jar
 Up and running with Blazegraph in under 30 seconds:  [Quick Start](https://wiki.blazegraph.com/wiki/index.php/Quick_Start).
 
-###Samples and Examples
+### Samples and Examples
 There are code samples and examples to get started with the Blazegraph Database [here] (https://github.com/blazegraph/blazegraph-samples).  Tinkerpop3 examples are included directly within the Tinkerpop3 repository per below.
 
-###Javadocs
+### Javadocs
 Click here to view the lastest [API Javadocs](https://blazegraph.github.io/database/apidocs/index.html).
 
-###Maven Central
+### Maven Central
 Starting with the 2.0.0 release, the Blazegraph Database is available on Maven Central.  To include the core platform and dependencies, include the artifact below in your dependencies.   [Developing with Maven](https://wiki.blazegraph.com/wiki/index.php/MavenNotes) has notes on developing with Blazegraph Database source code and Maven.
 
 ```
@@ -49,13 +49,13 @@ If you'd just link the Blazegraph Database dependencies without any of the exter
     </dependency>
 ```
 
-###Deployers
+### Deployers
 
 Starting with 2.0.0, the default context path for deployment is `http://localhost:9999/blazegraph/`.  There are also Maven artifacts for WAR deployers (`blazegraph-war`), executable Jar files (`blazegraph-jar`), [Debian Package](blazegraph-deb/) (`blazegraph-deb`), [RPM](blazegraph-rpm/) (`blazegraph-rpm`), and a [Tarball](blazegraph-tgz/) (`blazegraph-tgz`).
 
 The `bigdata-war` and `bigdata-jar` artifacts are included for legacy purposes and use the `/bigdata/` context path.
 
-###Tinkerpop3
+### Tinkerpop3
 Tinkerpop3 supports requires Java 1.8 and is now in a separate repository.  See [Tinkerpop3](https://github.com/blazegraph/tinkerpop3).  It is also available as Maven Central artifact.
 
 ```
@@ -67,7 +67,7 @@ Tinkerpop3 supports requires Java 1.8 and is now in a separate repository.  See 
     
 ```
 
-###Triple Pattern Fragment (TPF) Server
+### Triple Pattern Fragment (TPF) Server
 There is a [Triple Pattern Fragment (TPF) for Blazegraph](https://github.com/TPF4Blazegraph/TPF4Blazegraph) server that supports [Linked Data Fragments](http://linkeddatafragments.org/).
 
 ```
@@ -78,8 +78,8 @@ There is a [Triple Pattern Fragment (TPF) for Blazegraph](https://github.com/TPF
     </dependency>
 ```    
 
-###Blazegraph Python Client
+### Blazegraph Python Client
 There is a Blazegraph Python Client [here] (https://github.com/blazegraph/blazegraph-python)
 
-###Blazegraph Dot Net RDF Client
+### Blazegraph Dot Net RDF Client
 There is a Blazegraph Dot Net RDF Client [here](https://github.com/blazegraph/blazegraph-dotnetrdf)

--- a/Security.md
+++ b/Security.md
@@ -1,10 +1,10 @@
-##Reporting a Blazegraph Security Issue##
+## Reporting a Blazegraph Security Issue ##
 
 For customers and Blazegraph users, please send an email to security [at] blazegraph.com to report a security issue. You may send an encrypted message using the public key below.
 
 This alias is monitored on a daily basis.   All security reports are acknowledged within 24 hours.   Mitigations for reported security issues are made in a reasonable timeframe, which may be as quickly as 24 hours for high-severity issues.
 
-###Public Key###
+### Public Key ###
 Please use the public key below for transmitting any sensitive information to the security alias.
 
 ```

--- a/vocabularies/README.md
+++ b/vocabularies/README.md
@@ -1,7 +1,7 @@
-#Blazegraph Vocabularies
+# Blazegraph Vocabularies
 Blazegraph Custom Vocabularies and Inline URI factories are a great way to get the best load and query performance from Blazegraph.   This package contains some commonly used vocabularies for public data sets.
 
-##Pubchem
+## Pubchem
 The [Pubchem](https://pubchem.ncbi.nlm.nih.gov/rdf/) data set is widely used in industry and research. 
 
 _PubChemRDF content includes a number of semantic relationships, such as those between compounds and substances, the chemical descriptors associated with compounds and substances, the relationships between compounds, the provenance and attribution metadata of substances, and the concise bioactivity data view of substances._
@@ -14,7 +14,7 @@ com.bigdata.rdf.store.AbstractTripleStore.inlineURIFactory=com.blazegraph.vocab.
 com.bigdata.rdf.store.AbstractTripleStore.vocabularyClass=com.blazegraph.vocab.pubchem.PubChemVocabulary
 ```
 
-###An example with Pubchem Core
+### An example with Pubchem Core
 
 Download the core Pubchem subset based on the [examples](https://pubchem.ncbi.nlm.nih.gov/rdf/#_Toc421254667).  For this example, we'll use `/path/to/pubchem-core/`.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
