### PR TITLE
BLZG-9003: Add timeout for query parsing phase.

### DIFF
--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/QueryServlet.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/QueryServlet.java
@@ -649,10 +649,11 @@ public class QueryServlet extends BigdataRDFServlet {
          final String namespace = getNamespace(req);
 
          final long timestamp = getTimestamp(req);
-
+         final BigdataRDFContext context = getBigdataRDFContext();
+         final long timeout = BigdataRDFContext.getQueryTimeout(req, context.getConfig().queryTimeout);
          submitApiTask(
                new SparqlQueryTask(req, resp, namespace, timestamp, queryStr, includeInferred, bindings,
-                     getBigdataRDFContext())).get();
+                     context), timeout).get();
 
       } catch (Throwable t) {
 


### PR DESCRIPTION
Previously, while query evaluation was subject to timeout, query compiling was not.
Unfortunately, things like constant regexes (see BLZG-8999), which are evaluated
in compile phase, can also take unlimited amount of time.