### PR TITLE
BLZG-8999: Make regex() operation interruptible.

### DIFF
--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/InterruptibleCharSequence.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/InterruptibleCharSequence.java
@@ -1,0 +1,40 @@
+package com.bigdata.rdf.internal.constraints;
+/**
+ * CharSequence that noticed thread interrupts -- as might be necessary
+ * to recover from a loose regex on unexpected challenging input.
+ * From: https://stackoverflow.com/a/910798/214196
+ * @author gojomo
+ */
+public class InterruptibleCharSequence implements CharSequence {
+    /**
+     * Parent sequence.
+     */
+    private final CharSequence inner;
+
+    public InterruptibleCharSequence(CharSequence inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public char charAt(int index) {
+        if (Thread.interrupted()) { // clears flag if set
+            throw new RuntimeException(new InterruptedException());
+        }
+        return inner.charAt(index);
+    }
+
+    @Override
+    public int length() {
+        return inner.length();
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return new InterruptibleCharSequence(inner.subSequence(start, end));
+    }
+
+    @Override
+    public String toString() {
+        return inner.toString();
+    }
+}

--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/RegexBOp.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/RegexBOp.java
@@ -258,7 +258,7 @@ public class RegexBOp extends XSDBooleanIVValueExpression
                 
                 }
 
-                final boolean result = pattern.matcher(text).find();
+                final boolean result = pattern.matcher(new InterruptibleCharSequence(text)).find();
 
                 return result;
 


### PR DESCRIPTION
This patch implements a workaround described here:
https://stackoverflow.com/a/910798/214196
to make regex matches interruptible by using InterruptibleCharSequence.

Fixes BLZG-8999.