### PR TITLE
fix infinite delete queries

### DIFF
--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/DeleteServlet.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/DeleteServlet.java
@@ -338,11 +338,11 @@ public class DeleteServlet extends BigdataRDFServlet {
                   final FutureTask<Void> ft = new FutureTask<Void>(
                         queryTask);
 
-                  // Submit query for evaluation.
-                  context.queryService.execute(ft);
-
                   // Reads on the statements produced by the query.
                   final InputStream is = newPipedInputStream(os);
+
+                  // Submit query for evaluation.
+                  context.queryService.execute(ft);
 
                   // Run parser : visited statements will be deleted.
                   rdfParser.parse(is, baseURI);

--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/UpdateServlet.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/UpdateServlet.java
@@ -441,11 +441,11 @@ public class UpdateServlet extends BigdataRDFServlet {
 							final FutureTask<Void> ft = new FutureTask<Void>(
 									queryTask);
 
-							// Submit query for evaluation.
-							context.queryService.execute(ft);
-
 							// Reads on the statements produced by the query.
 							final InputStream is = newPipedInputStream(os);
+
+							// Submit query for evaluation.
+							context.queryService.execute(ft);
 
 							// Run parser : visited statements will be deleted.
 							rdfParser.parse(is, baseURI);


### PR DESCRIPTION
close piped output stream in case of exception during query execution and ensure connected pipe in delete and update tasks.