### PR TITLE
BLZG-9156: Add support for regex q option

### DIFF
--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/RegexBOp.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/RegexBOp.java
@@ -301,6 +301,7 @@ public class RegexBOp extends XSDBooleanIVValueExpression
             }
             int f = 0;
             for (char c : flags.toCharArray()) {
+                // See https://www.w3.org/TR/xpath-functions/#flags
                 switch (c) {
                     case 's':
                         f |= Pattern.DOTALL;
@@ -332,6 +333,9 @@ public class RegexBOp extends XSDBooleanIVValueExpression
                         break;
                     case 'u': // Implicit with 'i' flag.
 //                      f |= Pattern.UNICODE_CASE;
+                        break;
+                    case 'q':
+                        f |= Pattern.LITERAL;
                         break;
                     default:
                         throw new IllegalArgumentException();

--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/ReplaceBOp.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/constraints/ReplaceBOp.java
@@ -268,6 +268,7 @@ public class ReplaceBOp extends IVValueExpression<IV> implements INeedsMateriali
 		int f = 0;
 		if (flagString != null) {
 			for (char c : flagString.toCharArray()) {
+                // See https://www.w3.org/TR/xpath-functions/#flags
 				switch (c) {
 				case 's':
 					f |= Pattern.DOTALL;
@@ -286,6 +287,9 @@ public class ReplaceBOp extends IVValueExpression<IV> implements INeedsMateriali
 					break;
 				case 'u':
 					f |= Pattern.UNICODE_CASE;
+					break;
+				case 'q':
+					f |= Pattern.LITERAL;
 					break;
 				default:
 					throw new IllegalArgumentException(flagString);


### PR DESCRIPTION
See https://www.w3.org/TR/xpath-functions/#flags
Currently Blazegraph does not have support for this option, the patch adds it.

Test case:

SELECT * { BIND( replace("abc", ".", "Z", "q") as ?test) }

Should produce "abc", not "ZZZ" (or exception). 

