### PR TITLE
BLZG-9154: Surefire plugin needs fix for Java8

### DIFF
--- a/bigdata-core-test/pom.xml
+++ b/bigdata-core-test/pom.xml
@@ -87,6 +87,8 @@ See https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.h
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>com/bigdata/cache/lru/TestAll.java</include>
             <include>com/bigdata/io/TestAll.java</include>

--- a/bigdata-rdf-test/pom.xml
+++ b/bigdata-rdf-test/pom.xml
@@ -57,6 +57,8 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>com/bigdata/rdf/TestAll.java</include>
             <include>com/bigdata/rdf/internal/gis/TestAll.java</include>

--- a/bigdata-sails-test/pom.xml
+++ b/bigdata-sails-test/pom.xml
@@ -56,6 +56,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>com/bigdata/rdf/sail/TestAll.java</include>
             <include>com/bigdata/rdf/sail/webapp/TestAll.java</include>

--- a/colt/pom.xml
+++ b/colt/pom.xml
@@ -65,6 +65,8 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>**/TestAll.java</include>
             <include>**/*Test.java</include>

--- a/dsi-utils/pom.xml
+++ b/dsi-utils/pom.xml
@@ -65,6 +65,8 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>**/TestAll.java</include>
             <include>**/*Test.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,8 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <!-- https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>**/TestAll.java</include>
           </includes>


### PR DESCRIPTION
Fix for https://jira.blazegraph.com/browse/BLZG-9154:

surefire plugin 2.x have been broken due to a java security update. The
system class loader has to be disabled.
