### PR TITLE
BLZG-9162 Add capability to refuse new requests if executor service is overloaded.

### DIFF
--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/BigdataRDFServletContextListener.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/BigdataRDFServletContextListener.java
@@ -441,9 +441,20 @@ public class BigdataRDFServletContextListener implements
 
         }
 
+        final long executorMaxThreads;
+        {
+            final String s = getInitParameter( ConfigParams.EXECUTOR_SERVICE_MAX_THREADS);
+
+            executorMaxThreads = (s == null) ? 0 : Long.valueOf(s);
+
+            if (log.isInfoEnabled())
+                log.info(ConfigParams.EXECUTOR_SERVICE_MAX_THREADS + "=" + executorMaxThreads);
+
+        }
+
         final SparqlEndpointConfig config = new SparqlEndpointConfig(namespace,
                 timestamp, queryThreadPoolSize, describeEachNamedGraph,
-                readOnly, queryTimeout);
+                readOnly, queryTimeout, executorMaxThreads);
 
         rdfContext = new BigdataRDFContext(config, indexManager);
 

--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/ConfigParams.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/ConfigParams.java
@@ -187,4 +187,11 @@ public interface ConfigParams {
      * List of the services this instance is allowed to call out to.
      */
     String SERVICE_WHITELIST = "serviceWhitelist";
+
+    /**
+     * Executor service thread limit.
+     * This is a soft boundary - actual pool will be unlimited, but
+     * new queries would not be launched if the pool has more active threads than this.
+     */
+    String EXECUTOR_SERVICE_MAX_THREADS = "executorMaxThreads";
 }

--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/SparqlEndpointConfig.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/SparqlEndpointConfig.java
@@ -85,11 +85,21 @@ public class SparqlEndpointConfig {
      * @see ConfigParams#QUERY_TIMEOUT
      */
     final public long queryTimeout;
-    
+
+     /**
+      * Executor service thread limit.
+      * This is a soft boundary - actual pool will be unlimited, but
+      * new queries would not be launched if the pool has more active threads than this.
+      * If zero, there is no limit.
+      *
+      * @see ConfigParams#EXECUTOR_SERVICE_MAX_THREADS
+      */
+    final public long executorMaxThreads;
+
     public SparqlEndpointConfig(final String namespace, final long timestamp,
             final int queryThreadPoolSize,
             final boolean describeEachNamedGraph, final boolean readOnly,
-            final long queryTimeout) {
+            final long queryTimeout, final long executorMaxThreads) {
 
         if (namespace == null)
             throw new IllegalArgumentException();
@@ -104,11 +114,12 @@ public class SparqlEndpointConfig {
         this.queryThreadPoolSize = queryThreadPoolSize;
 
         this.describeEachNamedGraph = describeEachNamedGraph;
-        
+
         this.readOnly = readOnly;
-        
+
         this.queryTimeout = queryTimeout;
-        
+
+        this.executorMaxThreads = executorMaxThreads;
     }
 
 }


### PR DESCRIPTION
This is applied only to query service (updates, etc. not affected) and
disabled by default. It is controlled by executorMaxThreads servlet
parameter.

See also: https://github.com/blazegraph/database/issues/91
