### PR TITLE
Better explain display on timeout

### DIFF
--- a/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/QueryServlet.java
+++ b/bigdata-core/bigdata-sails/src/java/com/bigdata/rdf/sail/webapp/QueryServlet.java
@@ -1305,6 +1305,10 @@ public class QueryServlet extends BigdataRDFServlet {
 
             }
 
+            // Flush parts that can be done without waiting for query to finish.
+            // Also open <pre> tag so if the exception happens we're getting nice backtrace.
+            w.write("<pre>");
+            w.flush();
             try {
                 
                 /*
@@ -1338,7 +1342,9 @@ public class QueryServlet extends BigdataRDFServlet {
                 // Fall through and paint the query stats table(s).
                 
             }
-            
+
+            w.write("</pre>");
+            w.flush();
             
 			current.node("h2", "Query Evaluation Statistics");
 			


### PR DESCRIPTION
This allows explain function to still display proper information even if the underlying query times out. 

Bug: T223711
Change-Id: Ib1eafc44759a1d2b83f049ef3f4d4a83dc77b3fd