### PR TITLE
Fix handling of numbers that convert to negative longs

### DIFF
--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/InlineUnsignedIntegerURIHandler.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/InlineUnsignedIntegerURIHandler.java
@@ -90,6 +90,9 @@ public class InlineUnsignedIntegerURIHandler extends InlineURIHandler {
      */
     @SuppressWarnings("rawtypes")
 	public static AbstractLiteralIV createInlineIV(final long value) {
+    	if (value < 0L) {
+			return new XSDUnsignedLongIV(value + Long.MIN_VALUE);
+		}
 		if (value < 256L) {
 			return new XSDUnsignedByteIV((byte) (value + Byte.MIN_VALUE));
 		}

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/store/TestInlineURIs.java
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/store/TestInlineURIs.java
@@ -246,6 +246,7 @@ public class TestInlineURIs extends AbstractTripleStoreTestCase {
                 UNSIGNED_INT_NAMESPACE + Short.MAX_VALUE, true,//
                 UNSIGNED_INT_NAMESPACE + Integer.MAX_VALUE, true,//
                 UNSIGNED_INT_NAMESPACE + Long.MAX_VALUE, true,//
+                UNSIGNED_INT_NAMESPACE + "12148449524915690527", true,//
                 UNSIGNED_INT_NAMESPACE + "19223372036854775807", true,//
                 UNSIGNED_INT_NAMESPACE + "foo", false);
     }


### PR DESCRIPTION
Negative long numbers were stored as bytes and thus truncated to small values. 

Bug: https://phabricator.wikimedia.org/T223946
Change-Id: I9e8ce75581cd068fb365bbe207dc9fdf5b3913dc