### PR TITLE
Fix remote service URL handling to allow parameters

### DIFF
--- a/bigdata-client/src/main/java/com/bigdata/rdf/sail/webapp/client/AbstractConnectOptions.java
+++ b/bigdata-client/src/main/java/com/bigdata/rdf/sail/webapp/client/AbstractConnectOptions.java
@@ -227,6 +227,9 @@ public class AbstractConnectOptions implements IMimeTypes {
         if (requestParams == null)
             return;
         boolean first = true;
+        if (urlString.indexOf("?") >= 0) {
+            first = false;
+        }
         for (Map.Entry<String, String[]> e : requestParams.entrySet()) {
             final String name = e.getKey();
             final String[] vals = e.getValue();


### PR DESCRIPTION
Remote federation calls did not handle service URLs with parameters properly. 

Bug: T226603
Change-Id: Ic59f012097ac6ea6c23305e36dd70f961c2d1ad5