### PR TITLE
BLZG-9178

### DIFF
--- a/bigdata-core-test/pom.xml
+++ b/bigdata-core-test/pom.xml
@@ -431,7 +431,7 @@ See https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.h
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/bigdata-rdf-test/pom.xml
+++ b/bigdata-rdf-test/pom.xml
@@ -308,7 +308,7 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/bigdata-sails-test/pom.xml
+++ b/bigdata-sails-test/pom.xml
@@ -308,7 +308,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/dsi-utils/pom.xml
+++ b/dsi-utils/pom.xml
@@ -143,7 +143,13 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
-      <version>1.6</version>
+      <version>${apache.commons_configuration.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.martiansoftware</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
   </contributors>
   <properties>
     <icu.version>4.8</icu.version>
-    <zookeeper.version>3.4.5</zookeeper.version>
+    <zookeeper.version>3.4.14</zookeeper.version>
     <sesame.version>2.7.12</sesame.version>
     <jsonld.version>0.5.1</jsonld.version>
     <semargl.version>0.6.1</semargl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
     <lucene.version>5.5.0</lucene.version>
     <apache.commons_codec.version>1.4</apache.commons_codec.version>
     <apache.commons_configuration.version>1.10</apache.commons_configuration.version>
-    <apache.commons_fileupload.version>1.3.1</apache.commons_fileupload.version>
+    <apache.commons_fileupload.version>1.3.3</apache.commons_fileupload.version>
     <apache.commons_io.version>2.1</apache.commons_io.version>
     <apache.commons_logging.version>1.1.1</apache.commons_logging.version>
     <apache.httpclient.version>4.4</apache.httpclient.version>


### PR DESCRIPTION
https://jira.blazegraph.com/browse/BLZG-9178

Apache Fileuploads version update due to CVE-2016-3092:The MultipartStream class in Apache Commons Fileupload before 1.3.2, as used in Apache Tomcat 7.x before 7.0.70, 8.x before 8.0.36, 8.5.x before 8.5.3, and 9.x before 9.0.0.M7 and other products, allows remote attackers to cause a denial of service (CPU consumption) via a long boundary string.
Ref: https://nvd.nist.gov/vuln/detail/CVE-2016-3092

Update dsi-utils to use the same version for commons-configuration and commons-collections as other blazegraph modules to avoid versions conflicts.

Upgrade zookeeper version to 3.4.14 (the latest bugfix release for 3.4, as of 2 April, 2019)
