### PR TITLE
Unify and upgrade zookeeper versions

### DIFF
--- a/bigdata-core-test/pom.xml
+++ b/bigdata-core-test/pom.xml
@@ -431,7 +431,7 @@ See https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.h
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/bigdata-rdf-test/pom.xml
+++ b/bigdata-rdf-test/pom.xml
@@ -308,7 +308,7 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/bigdata-sails-test/pom.xml
+++ b/bigdata-sails-test/pom.xml
@@ -308,7 +308,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.5</version>
+      <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>com.blazegraph</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@ Copyright 2010 by TalkingTrends (Amsterdam, The Netherlands)
   </contributors>
   <properties>
     <icu.version>4.8</icu.version>
-    <zookeeper.version>3.4.5</zookeeper.version>
+    <zookeeper.version>3.4.14</zookeeper.version>
     <sesame.version>2.7.12</sesame.version>
     <jsonld.version>0.5.1</jsonld.version>
     <semargl.version>0.6.1</semargl.version>


### PR DESCRIPTION
Ref. https://jira.blazegraph.com/browse/BLZG-9178
Change-Id: I68a5001e939372e0e02ada8aab252905560533f3

Upgrade zookeeper version to 3.4.14 (the latest bugfix release for 3.4, as of 2 April, 2019)