### PR TITLE
Fix the dependency conflict issue

### DIFF
--- a/rdf-properties/pom.xml
+++ b/rdf-properties/pom.xml
@@ -113,5 +113,10 @@ ga('send', 'pageview');
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>
     </dependency>
+    <dependency>
+       <groupId>com.fasterxml.jackson.core</groupId>
+       <artifactId>jackson-core</artifactId>
+       <version>2.9.6</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Fix the dependency conflict issue #180 by solution: Declare version com.fasterxml.jackson.core:jackson-core:2.9.6 as a direct dependency.