### PR TITLE
Fix markdown formatting in vocabularies/README.md

### DIFF
--- a/vocabularies/README.md
+++ b/vocabularies/README.md
@@ -1,7 +1,9 @@
-#Blazegraph Vocabularies
+# Blazegraph Vocabularies
+
 Blazegraph Custom Vocabularies and Inline URI factories are a great way to get the best load and query performance from Blazegraph.   This package contains some commonly used vocabularies for public data sets.
 
-##Pubchem
+## Pubchem
+
 The [Pubchem](https://pubchem.ncbi.nlm.nih.gov/rdf/) data set is widely used in industry and research. 
 
 _PubChemRDF content includes a number of semantic relationships, such as those between compounds and substances, the chemical descriptors associated with compounds and substances, the relationships between compounds, the provenance and attribution metadata of substances, and the concise bioactivity data view of substances._
@@ -14,11 +16,11 @@ com.bigdata.rdf.store.AbstractTripleStore.inlineURIFactory=com.blazegraph.vocab.
 com.bigdata.rdf.store.AbstractTripleStore.vocabularyClass=com.blazegraph.vocab.pubchem.PubChemVocabulary
 ```
 
-###An example with Pubchem Core
+### An example with Pubchem Core
 
 Download the core Pubchem subset based on the [examples](https://pubchem.ncbi.nlm.nih.gov/rdf/#_Toc421254667).  For this example, we'll use `/path/to/pubchem-core/`.
 
-```
+```sh
 #!/bin/sh
     wget -r -A ttl.gz -nH --cut-dirs=3 -P compound ftp://ftp.ncbi.nlm.nih.gov/pubchem/RDF/compound/general
     wget -r -A ttl.gz -nH --cut-dirs=2 ftp://ftp.ncbi.nlm.nih.gov/pubchem/RDF/substance
@@ -44,7 +46,7 @@ Use the BulkLoader with the example [pubchem properties](src/main/resources/name
 
 Update the file below `dataloader.xml` with your local configuration for `pubchem.properties` and the `/path/to/pubchem/core` as well as any other configuration for your local machine.
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> 
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"> 
 	  <properties>
@@ -75,7 +77,7 @@ Update the file below `dataloader.xml` with your local configuration for `pubche
 
 Then post it into your running instance.
 
-```
+```sh
 curl -X POST --data-binary @dataloader.xml --header 'Content-Type:application/xml' http://localhost:9999/blazegraph/dataloader
 ```
 


### PR DESCRIPTION
The syntax of the markdown in `vocabularies/README.md` was incorrect for the headers. Because of a missing space ` ` behind the hash character `#` the headers were not rendered as headers.

This MR fixes that so that the headers are actually rendered as headers.

When editing the file I noticed the code blocks did not have a language indicator added.
These were added as well.